### PR TITLE
allow changing the path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: "Lhassan Baazzi <baazzilhassan@gmail.com>"
 inputs:
   path:
     description: "Path of the directory containing the static assets."
-    required: true
+    required: false
     default: "_site/"
 runs:
   using: composite
@@ -19,5 +19,5 @@ runs:
     - name: Genarate responsive images
       shell: bash
       run: |
-        npm exec jampack ./_site
-        rm -rf ./_site/_jampack
+        npm exec jampack ./${{ inputs.path }}
+        rm -rf ./${{ inputs.path }}/_jampack


### PR DESCRIPTION
the path variable is advertised, but isn't applied.
in order to use this action with other static site generators than jekyll it is necessary to be able to change the path